### PR TITLE
Express: add history api fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -399,6 +399,11 @@
         "typedarray": "0.0.6"
       }
     },
+    "connect-history-api-fallback": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+      "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "name": "prerender-plugin",
   "version": "1.0.6",
-  "description":
-    "A Node.js/webpack plugin to prerender static HTML in a single page application.",
-  "keywords": ["webpack", "prerender", "spa", "single page application"],
+  "description": "A Node.js/webpack plugin to prerender static HTML in a single page application.",
+  "keywords": [
+    "webpack",
+    "prerender",
+    "spa",
+    "single page application"
+  ],
   "homepage": "https://github.com/mubaidr/webpack-prerender-plugin",
   "bugs": {
     "url": "https://github.com/mubaidr/webpack-prerender-plugin/issues",
@@ -22,11 +26,12 @@
   "main": "index.js",
   "dependencies": {
     "compression": "^1.7.1",
+    "connect-history-api-fallback": "^1.5.0",
     "express": "^4.16.2",
+    "express-minify": "^1.0.0",
+    "fs-extra": "5.0.0",
     "lodash.defaultsdeep": "^4.6.0",
     "mkdirp": "^0.5.1",
-    "fs-extra": "5.0.0",
-    "express-minify": "^1.0.0",
     "portfinder": "^1.0.13",
     "puppeteer": "^0.13.0"
   },

--- a/util/server.js
+++ b/util/server.js
@@ -2,6 +2,7 @@ const express = require('express')
 const portfinder = require('portfinder')
 const compression = require('compression')
 const minify = require('express-minify')
+const history = require('connect-history-api-fallback')
 
 module.exports = {
   build: async root => {
@@ -14,6 +15,7 @@ module.exports = {
     }
 
     const app = express()
+    app.use(history())
     app.use(compression())
     app.use(minify())
     app.use(express.static(root))


### PR DESCRIPTION
Hello,

Thanks for this plugin it works great !

But with a js router with HTML5 History enabled, the plugin doesn't work.
To fix that, I added the[ history fallback middleware](https://github.com/bripkens/connect-history-api-fallback) for the express server. It allows to proxy requests through a specified index page.